### PR TITLE
Removing requirements for mysql and redis packages.

### DIFF
--- a/metaparticle-storage.js
+++ b/metaparticle-storage.js
@@ -2,14 +2,17 @@
     var storage = null;
     var q = require('q');
     var storageImpls = {
-        "file": require('./metaparticle-file-storage.js'),
-        "redis": require('./metaparticle-redis-storage'),
-        "mysql": require('./metaparticle-mysql-storage.js')
+        "file": './metaparticle-file-storage.js',
+        "redis": './metaparticle-redis-storage',
+        "mysql": './metaparticle-mysql-storage.js'
     }
 
     module.exports.setStorage = function(name, config) {
-        storage = storageImpls[name];
-        if (storage != null) {
+        // Does this storage method exist?
+        const file = storageImpls[name];
+        if ('undefined' !== typeof (file)) {
+            // Yes, initialise it.
+            storage = require(file);
             storage.configure(config);
         }
     }


### PR DESCRIPTION
I really like this module, however I had one issue when I had a project without the MySQL and Redis packages installed (for dev). It would fail as your code loads all three packages before the developer chooses one.

I have updated the code to not load any until the storage medium is chosen.

Please let me know what you think.